### PR TITLE
Added Maven POM.xml to allow hassle free project build + import into …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+**/.metadata
+**/*.classpath
+**/*.project
+
+**/.idea
+**/*.iml
+
+**/target

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ an implementation of the C4.5 algorithm in Java
 
 ---
 
-This is a basic exmaple of the C4.5 decision tree algorithm developed by Ross Quinlan.
+This is a basic example of the C4.5 decision tree algorithm developed by Ross Quinlan.
 C4.5 is generally used for classification and is oftern referred to as a statistical classifier.
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>scottjulian</groupId>
+	<artifactId>C4.5</artifactId>
+	<version>1.0</version>
+
+	<name>C4.5</name>
+	<description>Implementation of the C4.5 algorithm in Java</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+
+</project>


### PR DESCRIPTION
I would suggest to add Maven build into the project, because it enables users to import
downloaded sources into any Java IDE more easily = without need to explicitly configure setup details of the new created project.
